### PR TITLE
Prevent insertion of line breaks

### DIFF
--- a/src/main/java/de/scrum_master/galileo/filter/JsoupFilter.java
+++ b/src/main/java/de/scrum_master/galileo/filter/JsoupFilter.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Comment;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Document.OutputSettings;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
 import org.jsoup.select.Elements;
@@ -224,6 +225,7 @@ public class JsoupFilter extends BasicFilter {
 	}
 
 	private void writeDocument() {
+		document.outputSettings().prettyPrint(false);
 		output.print(document);
 	}
 
@@ -572,11 +574,8 @@ public class JsoupFilter extends BasicFilter {
 	}
 
 	private static void moveNodes(Elements sourceNodes, Element targetElement) {
-		for (Element element : sourceNodes) {
-			element.remove();
-			for (Node node : element.childNodes())
-				targetElement.append(node.outerHtml());
-		}
+		for (Element element : sourceNodes)
+			targetElement.insertChildren(-1, element.childNodes());
 	}
 
 	private static void replaceNode(Element original, Element replacement) {


### PR DESCRIPTION
Additional line breaks cause indentation of the first line and
double line spacing of all lines in code listings (class="listing")
of the java 8 book.

Jsoup inserts additional line breaks at appending child elements in
the moveNodes function. Instead of appending the children of the
removed source elements to the target element we now insert them
(they will be moved from their current parents).
Further we disable jsoup pretty printing.

Fixes issue # 36.